### PR TITLE
Hiding details from user contact info if not set

### DIFF
--- a/resources/views/backend/profile/index.blade.php
+++ b/resources/views/backend/profile/index.blade.php
@@ -76,7 +76,7 @@
                             </div>
                             <div class="pmbb-body p-l-30">
                                 <div class="pmbb-view">
-                                    @if(isset($data['phone']))
+                                    @if(isset($data['phone']) && strlen($data['phone']))
                                         <dl class="dl-horizontal">
                                             <dt>Mobile Phone</dt>
                                             <dd>{{ $data['phone'] }}</dd>
@@ -86,19 +86,19 @@
                                         <dt>Email Address</dt>
                                         <dd>{{ $data['email'] }}</dd>
                                     </dl>
-                                    @if(isset($data['twitter']))
+                                    @if(isset($data['twitter']) && strlen($data['twitter']))
                                         <dl class="dl-horizontal">
                                             <dt>Twitter</dt>
                                             <dd><a href="http://twitter.com/{{ $data['twitter'] }}" target="_blank">{{ '@' . $data['twitter'] }}</a></dd>
                                         </dl>
                                     @endif
-                                    @if(isset($data['facebook']))
+                                    @if(isset($data['facebook']) && strlen($data['facebook']))
                                         <dl class="dl-horizontal">
                                             <dt>Facebook</dt>
                                             <dd><a href="http://facebook.com/{{ $data['facebook'] }}" target="_blank">{{ $data['facebook'] }}</a></dd>
                                         </dl>
                                     @endif
-                                    @if(isset($data['github']))
+                                    @if(isset($data['github']) && strlen($data['github']))
                                         <dl class="dl-horizontal">
                                             <dt>GitHub</dt>
                                             <dd><a href="http://github.com/{{ $data['github'] }}" target="_blank">{{ $data['github'] }}</a></dd>

--- a/resources/views/backend/profile/partials/form/basic-information.blade.php
+++ b/resources/views/backend/profile/partials/form/basic-information.blade.php
@@ -20,7 +20,7 @@
 
 <div class="form-group">
     <div class="fg-line">
-        <label class="fg-label">Dispaly Name</label>
+        <label class="fg-label">Display Name</label>
         <input type="text" class="form-control" name="display_name" id="display_name" value="{{ $data['display_name'] }}" placeholder="Display Name">
     </div>
 </div>

--- a/resources/views/backend/profile/partials/sidebar.blade.php
+++ b/resources/views/backend/profile/partials/sidebar.blade.php
@@ -16,17 +16,17 @@
     <div class="pmo-block pmo-contact hidden-xs">
         <h2>Contact</h2>
         <ul>
-            @if(isset($data['phone']))
+            @if(isset($data['phone']) && strlen($data['phone']))
                 <li><i class="zmdi zmdi-phone"></i> {{ $data['phone'] }}</li>
             @endif
             <li><i class="zmdi zmdi-email"></i> <a href="mailto:{{ $data['email'] }}" target="_blank">{{ $data['email'] }}</a></li>
-            @if(isset($data['twitter']))
+            @if(isset($data['twitter']) && strlen($data['twitter']))
                 <li><i class="zmdi zmdi-twitter-box"></i> <a href="http://twitter.com/{{ $data['twitter'] }}" target="_blank">{{'@'.$data['twitter'] }}</a></li>
             @endif
-            @if(isset($data['facebook']))
+            @if(isset($data['facebook']) && strlen($data['facebook']))
                 <li><i class="zmdi zmdi-facebook-box"></i> <a href="http://facebook.com/{{ $data['facebook'] }}" target="_blank">{{ $data['facebook'] }}</a></li>
             @endif
-            @if(isset($data['github']))
+            @if(isset($data['github']) && strlen($data['github']))
                 <li><i class="zmdi zmdi-github-box"></i> <a href="http://github.com/{{ $data['facebook'] }}" target="_blank">{{ $data['github'] }}</a></li>
             @endif
             <li>

--- a/resources/views/frontend/blog/partials/header.blade.php
+++ b/resources/views/frontend/blog/partials/header.blade.php
@@ -3,13 +3,13 @@
         <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
             <h1><a href="/">{{ config('blog.title') }}</a></h1>
 
-            @if(isset($user->twitter))
+            @if(isset($user->twitter) && strlen($user->twitter))
                 <a href="http://twitter.com/{{ $user->twitter }}" target="_blank" id="social"><i class="fa fa-fw fa-twitter"></i></a>
             @endif
-            @if(isset($user->facebook))
+            @if(isset($user->facebook) && strlen($user->facebook))
                 <a href="http://facebook.com/{{ $user->facebook }}" target="_blank" id="social"><i class="fa fa-fw fa-facebook"></i></a>
             @endif
-            @if(isset($user->github))
+            @if(isset($user->github) && strlen($user->github))
                 <a href="http://github.com/{{ $user->github }}" target="_blank" id="social"><i class="fa fa-fw fa-github"></i></a>
             @endif
         </div>


### PR DESCRIPTION
Previously if I didn't set my Facebook, Twitter or GitHub username it would still show up in the sidebar and user profile section, without a value, as well as as an icon in the frontend. This is now changed by simply hiding them if they don't have a value.