### PR TITLE
Refactor tests (fix bug #14) and cast post model published_at property

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ install:
   - composer install
 
 before_script:
-  - mysql -u root -e 'create database canvas;'
-  - export DB_DATABASE=canvas
+  - mysql -u root -e 'create database canvas_testing;'
+  - export DB_DATABASE=canvas_testing
   - export DB_USERNAME=root
   - export DB_PASSWORD=
 

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -8,6 +8,13 @@ use Illuminate\Database\Eloquent\Model;
 class Post extends Model
 {
     /**
+     * The attributes that should be mutated to dates.
+     *
+     * @var array
+     */
+    protected $dates = ['published_at'];
+    
+    /**
      * The attributes that are mass assignable.
      *
      * @var array

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
     },
     "autoload-dev": {
         "classmap": [
-            "tests/TestCase.php"
+            "tests/TestCase.php",
+            "tests/InteractsWithDatabase.php"
         ]
     },
     "scripts": {

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -61,15 +61,11 @@ $factory->define(App\Models\Tag::class, function ($faker) {
 $factory->define(App\Models\User::class, function(Faker\Generator $faker) {
 
     return [
-        'bio'           => $faker->sentences(1, true),
-        'first_name'    => $faker->firstName,
-        'last_name'     => $faker->lastName,
-        'display_name'  => $faker->userName,
+        'first_name'    => $first = $faker->firstName,
+        'last_name'     => $last = $faker->lastName,
+        'display_name'  => $first . ' ' . $last,
         'job'           => $faker->jobTitle,
-        'gender'        => 'Male',
         'birthday'      => $faker->date('Y-m-d'),
-        'relationship'  => 'Married',
-        'phone'         => $faker->phoneNumber,
         'email'         => $faker->safeEmail,
         'twitter'       => 'canvas',
         'facebook'      => 'canvas',

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -49,3 +49,36 @@ $factory->define(App\Models\Tag::class, function ($faker) {
     'created_at'        => Carbon\Carbon::now(),
   ];
 });
+
+/*
+|--------------------------------------------------------------------------
+| User Model Factory
+|--------------------------------------------------------------------------
+|
+| Create a user model in the database.
+|
+*/
+$factory->define(App\Models\User::class, function(Faker\Generator $faker) {
+
+    return [
+        'bio'           => $faker->sentences(1, true),
+        'first_name'    => $faker->firstName,
+        'last_name'     => $faker->lastName,
+        'display_name'  => $faker->userName,
+        'job'           => $faker->jobTitle,
+        'gender'        => 'Male',
+        'birthday'      => $faker->date('Y-m-d'),
+        'relationship'  => 'Married',
+        'phone'         => $faker->phoneNumber,
+        'email'         => $faker->safeEmail,
+        'twitter'       => 'canvas',
+        'facebook'      => 'canvas',
+        'github'        => 'canvas',
+        'address'       => $faker->streetAddress,
+        'city'          => $faker->city,
+        'state'         => 'MN',
+        'url'           => $faker->url,
+        'password'      => bcrypt('password'),
+
+    ];
+});

--- a/database/seeds/TestDatabaseSeeder.php
+++ b/database/seeds/TestDatabaseSeeder.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class TestDatabaseSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $this->call('PostTableSeeder');
+        $this->call('TagTableSeeder');
+        $this->call('PostTagPivotTableSeeder');
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,6 +21,7 @@
     </filter>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="DB_DATABASE" value="canvas_testing"></env>
         <env name="CACHE_DRIVER" value="array"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="QUEUE_DRIVER" value="sync"/>

--- a/resources/views/frontend/blog/index.blade.php
+++ b/resources/views/frontend/blog/index.blade.php
@@ -8,7 +8,7 @@
     <div class="container">
         <div class="row">
             <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
-                @if (!empty($tag->title))
+                @if (isset($tag->title))
                     <p class="tag-link">Explore <a href="#">{{ $tag->title or '' }}</a></p>
                     <p class="tag-subtitle">- {{ $tag->subtitle }} -</p>
                 @endif
@@ -19,11 +19,10 @@
                             <a href="{{ $post->url($tag) }}">{{ $post->title }}</a>
                         </h2>
                         <p class="post-meta">
-                            {{ \Carbon\Carbon::createFromFormat('Y-m-d H:i:s', $post->published_at)->diffForHumans() }}
-                            @if ($post->tags->count())
-                                in
-                                {!! join(', ', $post->tagLinks()) !!}
-                            @endif
+                            {{ $post->published_at->diffForHumans() }}
+                            @unless ($post->tags->isEmpty())
+                                in {!! implode(', ', $post->tagLinks()) !!}
+                            @endunless
                         </p>
                     </div>
                     <hr>

--- a/tests/Acceptance/AdminRoutesTest.php
+++ b/tests/Acceptance/AdminRoutesTest.php
@@ -10,19 +10,26 @@ use Illuminate\Foundation\Testing\DatabaseTransactions;
  */
 class AdminRoutesTest extends TestCase
 {
-    use DatabaseMigrations, DatabaseTransactions;
+    use InteractsWithDatabase;
 
     /**
-     * Authenticate a user and log them in for further tests.
+     * The user model.
+     * 
+     * @var App\Models\User
      */
-    private function userLogin()
+    private $user;
+
+    /**
+     * Create the user model test subject.
+     *
+     * @before
+     * @return void
+     */
+    public function createUser()
     {
-        $this->seed(UsersTableSeeder::class);
-        $this->visit('/auth/login')
-            ->type('admin@canvas.com', 'email')
-            ->type('password', 'password')
-            ->press('submit')
-            ->seePageIs('/admin/post');
+
+        $this->user = factory(App\Models\User::class)->create();
+
     }
 
     /**
@@ -32,8 +39,7 @@ class AdminRoutesTest extends TestCase
      */
     public function testPostsPageResponseCode()
     {
-        $this->userLogin();
-        $response = $this->call('GET', '/admin/post');
+        $response = $this->actingAs($this->user)->call('GET', '/admin/post');
         $this->assertEquals(200, $response->status());
     }
 
@@ -44,8 +50,7 @@ class AdminRoutesTest extends TestCase
      */
     public function testTagsPageResponseCode()
     {
-        $this->userLogin();
-        $response = $this->call('GET', '/admin/tag');
+        $response = $this->actingAs($this->user)->call('GET', '/admin/tag');
         $this->assertEquals(200, $response->status());
     }
 
@@ -56,8 +61,8 @@ class AdminRoutesTest extends TestCase
      */
     public function testUploadsPageResponseCode()
     {
-        $this->userLogin();
-        $response = $this->call('GET', '/admin/upload');
+
+        $response = $this->actingAs($this->user)->call('GET', '/admin/upload');
         $this->assertEquals(200, $response->status());
     }
 
@@ -68,8 +73,7 @@ class AdminRoutesTest extends TestCase
      */
     public function testProfilePageResponseCode()
     {
-        $this->userLogin();
-        $response = $this->call('GET', '/admin/profile');
+        $response = $this->actingAs($this->user)->call('GET', '/admin/profile');
         $this->assertEquals(200, $response->status());
     }
 }

--- a/tests/Acceptance/AuthenticationTest.php
+++ b/tests/Acceptance/AuthenticationTest.php
@@ -1,8 +1,5 @@
 <?php
 
-use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
-
 /**
  * Class AuthenticationTest
  *
@@ -11,7 +8,27 @@ use Illuminate\Foundation\Testing\DatabaseTransactions;
 class AuthenticationTest extends TestCase
 {
 
-    use DatabaseMigrations, DatabaseTransactions;
+    use InteractsWithDatabase;
+
+    /**
+     * The user model.
+     *
+     * @var App\Users\User
+     */
+    private $user;
+
+    /**
+     * Create the user model test subject.
+     * 
+     * @before
+     * @return void
+     */
+    public function createUser()
+    {
+
+        $this->user = factory(App\Models\User::class)->create();
+
+    }
 
     /**
      * Test the ability for a user to log into the application.
@@ -20,11 +37,12 @@ class AuthenticationTest extends TestCase
      */
     public function testApplicationLogin()
     {
-        $this->seed(UsersTableSeeder::class);
+
         $this->visit('/auth/login')
-             ->type('admin@canvas.com', 'email')
+             ->type($this->user->email, 'email')
              ->type('password', 'password')
              ->press('submit')
+             ->seeIsAuthenticatedAs($this->user)
              ->seePageIs('/admin/post');
     }
 
@@ -35,13 +53,12 @@ class AuthenticationTest extends TestCase
      */
     public function testApplicationLogout()
     {
-        $this->seed(UsersTableSeeder::class);
-        $this->visit('/auth/login')
-             ->type('admin@canvas.com', 'email')
-             ->type('password', 'password')
-             ->press('submit')
-             ->seePageIs('/admin/post')
+
+        $this->actingAs($this->user)
+             ->visit('/admin/post')
              ->click('logout')
-             ->seePageis('/auth/login');
+             ->seePageis('/auth/login')
+             ->dontSeeIsAuthenticated();
     }
+
 }

--- a/tests/Acceptance/PublicRoutesTest.php
+++ b/tests/Acceptance/PublicRoutesTest.php
@@ -1,8 +1,5 @@
 <?php
 
-use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
-
 /**
  * Class PublicRoutesTest
  *
@@ -11,7 +8,7 @@ use Illuminate\Foundation\Testing\DatabaseTransactions;
 class PublicRoutesTest extends TestCase
 {
 
-    use DatabaseMigrations, DatabaseTransactions;
+    use InteractsWithDatabase;
 
     /**
      * Test the response code for the Blog page.
@@ -20,7 +17,8 @@ class PublicRoutesTest extends TestCase
      */
     public function testBlogPageResponseCode()
     {
-        $this->seed(DatabaseSeeder::class);
+
+        factory(App\Models\User::class)->create();
         $response = $this->call('GET', '/');
         $this->assertEquals(200, $response->status());
     }

--- a/tests/InteractsWithDatabase.php
+++ b/tests/InteractsWithDatabase.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+trait InteractsWithDatabase
+{
+
+    use DatabaseTransactions;
+
+    /**
+     * Setup the test environment.
+     *
+     * @return void
+     */
+    protected function setUp() {
+
+        parent::setUp();
+
+        $this->runDatabaseMigrations();
+
+        $this->seed(TestDatabaseSeeder::class);
+
+    }
+
+    /**
+     * Define hooks to migrate the database before and after each test.
+     *
+     * @return void
+     */
+    public function runDatabaseMigrations()
+    {
+        $this->artisan('migrate');
+
+        $this->beforeApplicationDestroyed(function () {
+            $this->artisan('migrate:reset');
+        });
+    }
+
+}


### PR DESCRIPTION
I was testing out your application and thought what you had was great, **simple** start. I attempted to run the tests and encountered bug #14. Which led me down the road of digging into your tests, and some other parts of your codebase pretty thoroughly. 

To run your tests (with my fix) make sure you have created a `canvas_testing` database first. This will eliminate bug #14. 

### What did I do
I updated the way you were logging in your the user in your tests and created a user model factory for testing purposes as well. For every test you were repeating the same assertions (userLogin()). Laravel provides some nice test helpers such as the `actingAs` method so you can skip right to the point of the authenticated test. There were also a few places you could use things shortcuts such as `seeIsAuthenticated(As)` methods, etc. 

I also created a `InteractsWithDatabase` trait that uses the Laravel `DatabaseTransactions` trait. You will also see that I copied over and changed the `runDatabaseMigrations` method from the `DatabaseMigrations` trait... I changed it to reset the database migrations after each test to prevent an error caused by the migrations not being run when they should.

Last but not least.. I also added the the published_at field to the dates array in the Post model. This means when you call `$post->published_at`, it will already be casted to a Carbon instance. In turn, I updated the `index.blade.php` view to use the published_at Carbon instance.

Thanks,

Erik


