### PR TITLE
Add default values to posts table migration

### DIFF
--- a/database/migrations/2015_06_27_123303_restructure_posts_table.php
+++ b/database/migrations/2015_06_27_123303_restructure_posts_table.php
@@ -13,12 +13,12 @@ class RestructurePostsTable extends Migration
     public function up()
     {
         Schema::table('posts', function (Blueprint $table) {
-            $table->string('subtitle')->after('title');
+            $table->string('subtitle')->after('title')->default('');
             $table->renameColumn('content', 'content_raw');
-            $table->text('content_html')->after('content');
-            $table->string('page_image')->after('content_html');
-            $table->string('meta_description')->after('page_image');
-            $table->boolean('is_draft')->after('meta_description');
+            $table->text('content_html')->after('content')->default('');
+            $table->string('page_image')->after('content_html')->default('');
+            $table->string('meta_description')->after('page_image')->default('');
+            $table->boolean('is_draft')->after('meta_description')->default(false);
             $table->string('layout')->after('is_draft')->default('frontend.blog.post');
         });
     }


### PR DESCRIPTION
Add default values to all new columns in the posts table restructuring
migration so that these migrations can be run on an sqlite database.

Fixes #22 (thanks @talv86!)