### PR TITLE
Update testing env to use sqlite:memory:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ php:
   - 5.6
   - 7.0
 
-services:
-  - mysql
-
 before_install:
   - mv .env.example .env
 
@@ -15,13 +12,6 @@ install:
   - /home/travis/.phpenv/versions/5.5.9/bin/composer self-update
   - composer install
 
-before_script:
-  - mysql -u root -e 'create database canvas_testing;'
-  - export DB_DATABASE=canvas_testing
-  - export DB_USERNAME=root
-  - export DB_PASSWORD=
-
 script:
   - php artisan key:generate
-  - php artisan migrate --seed
   - vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@
 
 <p align="center">
   <a href="https://travis-ci.org/austintoddj/Canvas"><img src="https://travis-ci.org/austintoddj/Canvas.svg?branch=master" alt="Build Status"></a>
-
+  
   <a href="https://github.com/austintoddj/Canvas/issues"><img src="https://img.shields.io/github/issues/austintoddj/Canvas.svg" alt="GitHub Issues"></a>
-
+  
   <a href="https://packagist.org/packages/austintoddj/canvas"><img src="https://poser.pugx.org/austintoddj/canvas/downloads" alt="Total Downloads"></a>
-
+  
   <a href="https://github.com/austintoddj/Canvas/stargazers"><img src="https://img.shields.io/github/stars/austintoddj/Canvas.svg" alt="Stars"></a>
-
+  
   <a href="https://github.com/austintoddj/Canvas/network"><img src="https://img.shields.io/github/forks/austintoddj/Canvas.svg" alt="GitHub Forks"></a>
-
+  
   <a href="https://packagist.org/packages/austintoddj/canvas"><img src="https://poser.pugx.org/austintoddj/canvas/v/stable" alt="Latest Stable Version"></a>
-
+  
   <a href="https://github.com/austintoddj/Canvas/blob/master/LICENSE"><img src="https://poser.pugx.org/austintoddj/canvas/license" alt="License"></a>
-
+  
   <br><br>
 
   Canvas is a minimal blogging application for developers. It attempts to make blogging simple and enjoyable by utilizing the latest technologies and keeping the administration as simple as possible with the primary focus on writing.
@@ -121,10 +121,6 @@ After you make any modifications to the files in `Canvas/resources/assets/less/`
 ```sh
 gulp
 ```
-
-## Unit Testing
-
-This section is optional. If you do not want to run unit tests on your application and just want to get straight to blogging, that's completely up to you. If you do choose to utilize the test suite bundled with Canvas, you will need to create a test database called, `canvas_testing`. After you've created it, you can safely test your application without affecting real data.
 
 ## Disqus Comments
 

--- a/config/database.php
+++ b/config/database.php
@@ -48,7 +48,7 @@ return [
 
         'sqlite' => [
             'driver'   => 'sqlite',
-            'database' => storage_path('database.sqlite'),
+            'database' => env('DB_DATABASE', storage_path('database.sqlite')),
             'prefix'   => '',
         ],
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,7 +21,8 @@
     </filter>
     <php>
         <env name="APP_ENV" value="testing"/>
-        <env name="DB_DATABASE" value="canvas_testing"></env>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="CACHE_DRIVER" value="array"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="QUEUE_DRIVER" value="sync"/>


### PR DESCRIPTION
Just switches the tests to use sqlite in memory database, no need to create a new database and better performance.

Just for reference #20 