### PR TITLE
Separate profile privacy

### DIFF
--- a/app/Http/Controllers/Backend/ProfileController.php
+++ b/app/Http/Controllers/Backend/ProfileController.php
@@ -42,6 +42,13 @@ class ProfileController extends Controller
         return view('backend.profile.edit', compact('data'));
     }
 
+    public function editPrivacy()
+    {
+        return view('backend.profile.privacy', [
+            "data" => array_merge(Auth::user()->toArray(), config('blog'))
+        ]);
+    }
+
     /**
      * Update the user profile information.
      *

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -27,6 +27,7 @@ $router->group([
     Route::delete('admin/upload/file', 'UploadController@deleteFile');
     Route::post('admin/upload/folder', 'UploadController@createFolder');
     Route::delete('admin/upload/folder', 'UploadController@deleteFolder');
+    Route::get('admin/profile/privacy', 'ProfileController@editPrivacy')->name('admin.profile.privacy');
     Route::resource('admin/profile', 'ProfileController');
     Route::resource('admin/search', 'SearchController');
 });

--- a/resources/views/backend/profile/edit.blade.php
+++ b/resources/views/backend/profile/edit.blade.php
@@ -1,100 +1,64 @@
-@extends('backend.layout')
+@extends('backend.profile.layout')
 
 @section('title')
     <title>{{ config('blog.title') }} | Edit Profile</title>
 @stop
 
-@section('content')
-    <section id="main">
+@section('profile-content')
+    @parent
+    <div class="pmb-block">
+        <div class="pmbb-header">
+            <h2><i class="zmdi zmdi-shield-security m-r-10"></i> Change Password</h2>
+        </div>
 
-        @include('backend.partials.sidebar-navigation')
+        <div class="pmbb-body p-l-30">
+            @include('backend.profile.partials.form.password')
+        </div>
+    </div>
 
-        <section id="content">
-            <div class="container container-alt">
+    <form class="keyboard-save" role="form" method="POST" id="profileUpdate" action="{{ route('admin.profile.update', Auth::user()->id) }}">
+        <input type="hidden" name="_token" value="{{ csrf_token() }}">
+        <input type="hidden" name="_method" value="PUT">
 
-                <div class="block-header">
-                    <h2>{{ Auth::user()->display_name }}
-                        <small>{{ Auth::user()->job }}, {{ Auth::user()->city }}, {{ Auth::user()->country }}</small>
-                    </h2>
-                </div>
+        <div class="pmb-block">
+            <div class="pmbb-header">
 
-                <div class="card" id="profile-main">
-
-                    @include('backend.profile.partials.sidebar')
-
-                    <div class="pm-body clearfix">
-                        <ul class="tab-nav tn-justified">
-                            <li><a href="/admin/profile">Profile</a></li>
-                            <li class="active"><a href="/admin/profile/{{ Auth::user()->id }}/edit">Settings</a></li>
-                        </ul>
-
-                        @if(Session::has('errors') || Session::has('success'))
-                            <div class="pmb-block">
-                                <div class="pmbb-header">
-                                    @include('shared.errors')
-                                    @include('shared.success')
-                                </div>
-                            </div>
-                        @endif
-
-                        <div class="pmb-block">
-                            <div class="pmbb-header">
-                                <h2><i class="zmdi zmdi-shield-security m-r-10"></i> Change Password</h2>
-                            </div>
-
-                            <div class="pmbb-body p-l-30">
-                                @include('backend.profile.partials.form.password')
-                            </div>
-                        </div>
-
-                        <form class="keyboard-save" role="form" method="POST" id="profileUpdate" action="{{ route('admin.profile.update', Auth::user()->id) }}">
-                            <input type="hidden" name="_token" value="{{ csrf_token() }}">
-                            <input type="hidden" name="_method" value="PUT">
-
-                            <div class="pmb-block">
-                                <div class="pmbb-header">
-
-                                    <h2><i class="zmdi zmdi-equalizer m-r-10"></i> Summary</h2>
-                                </div>
-                                <div class="pmbb-body p-l-30">
-
-                                    @include('backend.profile.partials.form.summary')
-
-                                </div>
-                            </div>
-
-                            <div class="pmb-block">
-                                <div class="pmbb-header">
-                                    <h2><i class="zmdi zmdi-account m-r-10"></i> Basic Information</h2>
-                                </div>
-                                <div class="pmbb-body p-l-30">
-
-                                    @include('backend.profile.partials.form.basic-information')
-
-                                </div>
-                            </div>
-
-                            <div class="pmb-block">
-                                <div class="pmbb-header">
-                                    <h2><i class="zmdi zmdi-phone m-r-10"></i> Contact Information</h2>
-                                </div>
-                                <div class="pmbb-body p-l-30">
-
-                                    @include('backend.profile.partials.form.contact-information')
-
-                                </div>
-                                <div class="form-group m-l-30">
-                                    <button type="submit" class="btn btn-primary btn-icon-text"><i class="zmdi zmdi-floppy"></i> Save</button>
-                                    &nbsp;
-                                    <a href="/admin/profile"><button type="button" class="btn btn-link">Cancel</button></a>
-                                </div>
-                            </div>
-                        </form>
-                    </div>
-                </div>
+                <h2><i class="zmdi zmdi-equalizer m-r-10"></i> Summary</h2>
             </div>
-        </section>
-    </section>
+            <div class="pmbb-body p-l-30">
+
+                @include('backend.profile.partials.form.summary')
+
+            </div>
+        </div>
+
+        <div class="pmb-block">
+            <div class="pmbb-header">
+                <h2><i class="zmdi zmdi-account m-r-10"></i> Basic Information</h2>
+            </div>
+            <div class="pmbb-body p-l-30">
+
+                @include('backend.profile.partials.form.basic-information')
+
+            </div>
+        </div>
+
+        <div class="pmb-block">
+            <div class="pmbb-header">
+                <h2><i class="zmdi zmdi-phone m-r-10"></i> Contact Information</h2>
+            </div>
+            <div class="pmbb-body p-l-30">
+
+                @include('backend.profile.partials.form.contact-information')
+
+            </div>
+            <div class="form-group m-l-30">
+                <button type="submit" class="btn btn-primary btn-icon-text"><i class="zmdi zmdi-floppy"></i> Save</button>
+                &nbsp;
+                <a href="/admin/profile"><button type="button" class="btn btn-link">Cancel</button></a>
+            </div>
+        </div>
+    </form>
 @stop
 
 @section('unique-js')

--- a/resources/views/backend/profile/edit.blade.php
+++ b/resources/views/backend/profile/edit.blade.php
@@ -6,15 +6,6 @@
 
 @section('profile-content')
     @parent
-    <div class="pmb-block">
-        <div class="pmbb-header">
-            <h2><i class="zmdi zmdi-shield-security m-r-10"></i> Change Password</h2>
-        </div>
-
-        <div class="pmbb-body p-l-30">
-            @include('backend.profile.partials.form.password')
-        </div>
-    </div>
 
     <form class="keyboard-save" role="form" method="POST" id="profileUpdate" action="{{ route('admin.profile.update', Auth::user()->id) }}">
         <input type="hidden" name="_token" value="{{ csrf_token() }}">

--- a/resources/views/backend/profile/index.blade.php
+++ b/resources/views/backend/profile/index.blade.php
@@ -1,133 +1,105 @@
-@extends('backend.layout')
+@extends('backend.profile.layout')
 
-@section('title')
-    <title>{{ config('blog.title') }} | Profile</title>
-@stop
-
-@section('content')
-    <section id="main">
-        @include('backend.partials.sidebar-navigation')
-        <section id="content">
-            <div class="container container-alt">
-
-                <div class="block-header">
-                    <h2>{{ $data['display_name'] }}
-                        <small>{{ $data['job'] }}, {{ $data['city'] }}, {{ $data['country'] }}</small>
-                    </h2>
-                </div>
-
-                <div class="card" id="profile-main">
-                    @include('backend.profile.partials.sidebar')
-
-                    <div class="pm-body clearfix">
-                        <ul class="tab-nav tn-justified">
-                            <li class="active"><a href="{{url('admin/profile')}}">Profile</a></li>
-                            <li><a href="{{route('admin.profile.edit', $data['id'])}}">Settings</a></li>
-                        </ul>
-
-                        @if(isset($data['bio']) && !empty($data['bio']))
-                            <div class="pmb-block">
-                                <div class="pmbb-header">
-                                    <h2><i class="zmdi zmdi-equalizer m-r-10"></i> Summary</h2>
-                                </div>
-                                <div class="pmbb-body p-l-30">
-                                    <div class="pmbb-view">
-                                        {{ $data['bio'] }}
-                                    </div>
-                                </div>
-                            </div>
-                        @endif
-
-                        <div class="pmb-block">
-                            <div class="pmbb-header">
-                                <h2><i class="zmdi zmdi-account m-r-10"></i> Basic Information</h2>
-                            </div>
-                            <div class="pmbb-body p-l-30">
-                                <div class="pmbb-view">
-                                    <dl class="dl-horizontal">
-                                        <dt>Full Name</dt>
-                                        <dd>{{ $data['first_name'] . ' ' . $data['last_name']}}</dd>
-                                    </dl>
-                                    @if(isset($data['gender']) && !empty($data['gender']))
-                                        <dl class="dl-horizontal">
-                                            <dt>Gender</dt>
-                                            <dd>{{ $data['gender'] }}</dd>
-                                        </dl>
-                                    @endif
-                                    @if(isset($data['birthday']) && !empty($data['birthday']))
-                                        <dl class="dl-horizontal">
-                                            <dt>Birthday</dt>
-                                            <dd>{{ \Carbon\Carbon::createFromFormat('Y-m-d', $data['birthday'])->format('M d, Y') }}</dd>
-                                        </dl>
-                                    @endif
-                                    @if(isset($data['relationship']) && !empty($data['relationship']) )
-                                        <dl class="dl-horizontal">
-                                            <dt>Relationship Status</dt>
-                                            <dd>{{ $data['relationship'] }}</dd>
-                                        </dl>
-                                    @endif
-                                </div>
-                            </div>
-                        </div>
-
-                        <div class="pmb-block">
-                            <div class="pmbb-header">
-                                <h2><i class="zmdi zmdi-phone m-r-10"></i> Contact Information</h2>
-                            </div>
-                            <div class="pmbb-body p-l-30">
-                                <div class="pmbb-view">
-                                    @if(isset($data['phone']) && strlen($data['phone']))
-                                        <dl class="dl-horizontal">
-                                            <dt>Mobile Phone</dt>
-                                            <dd>{{ $data['phone'] }}</dd>
-                                        </dl>
-                                    @endif
-                                    <dl class="dl-horizontal">
-                                        <dt>Email Address</dt>
-                                        <dd>{{ $data['email'] }}</dd>
-                                    </dl>
-                                    @if(isset($data['twitter']) && strlen($data['twitter']))
-                                        <dl class="dl-horizontal">
-                                            <dt>Twitter</dt>
-                                            <dd><a href="http://twitter.com/{{ $data['twitter'] }}" target="_blank">{{ '@' . $data['twitter'] }}</a></dd>
-                                        </dl>
-                                    @endif
-                                    @if(isset($data['facebook']) && strlen($data['facebook']))
-                                        <dl class="dl-horizontal">
-                                            <dt>Facebook</dt>
-                                            <dd><a href="http://facebook.com/{{ $data['facebook'] }}" target="_blank">{{ $data['facebook'] }}</a></dd>
-                                        </dl>
-                                    @endif
-                                    @if(isset($data['github']) && strlen($data['github']))
-                                        <dl class="dl-horizontal">
-                                            <dt>GitHub</dt>
-                                            <dd><a href="http://github.com/{{ $data['github'] }}" target="_blank">{{ $data['github'] }}</a></dd>
-                                        </dl>
-                                    @endif
-                                    @if(isset($data['address']) && !empty($data['address']))
-                                        <dl class="dl-horizontal">
-                                            <dt>Address</dt>
-                                            <dd>{{ $data['address'] }}</dd>
-                                        </dl>
-                                    @endif
-                                    @if(isset($data['city']) && !empty($data['city']))
-                                        <dl class="dl-horizontal">
-                                            <dt>City</dt>
-                                            <dd>{{ $data['city'] }}</dd>
-                                        </dl>
-                                    @endif
-                                    @if(isset($data['country']) && !empty($data['country']))
-                                        <dl class="dl-horizontal">
-                                            <dt>Country</dt>
-                                            <dd>{{ $data['country'] }}</dd>
-                                        </dl>
-                                    @endif
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+@section('profile-content')
+    @parent
+    @if(isset($data['bio']) && !empty($data['bio']))
+        <div class="pmb-block">
+            <div class="pmbb-header">
+                <h2><i class="zmdi zmdi-equalizer m-r-10"></i> Summary</h2>
+            </div>
+            <div class="pmbb-body p-l-30">
+                <div class="pmbb-view">
+                    {{ $data['bio'] }}
                 </div>
             </div>
-        </section>
-    </section>
+        </div>
+    @endif
+
+    <div class="pmb-block">
+        <div class="pmbb-header">
+            <h2><i class="zmdi zmdi-account m-r-10"></i> Basic Information</h2>
+        </div>
+        <div class="pmbb-body p-l-30">
+            <div class="pmbb-view">
+                <dl class="dl-horizontal">
+                    <dt>Full Name</dt>
+                    <dd>{{ $data['first_name'] . ' ' . $data['last_name']}}</dd>
+                </dl>
+                @if(isset($data['gender']) && !empty($data['gender']))
+                    <dl class="dl-horizontal">
+                        <dt>Gender</dt>
+                        <dd>{{ $data['gender'] }}</dd>
+                    </dl>
+                @endif
+                @if(isset($data['birthday']) && !empty($data['birthday']))
+                    <dl class="dl-horizontal">
+                        <dt>Birthday</dt>
+                        <dd>{{ \Carbon\Carbon::createFromFormat('Y-m-d', $data['birthday'])->format('M d, Y') }}</dd>
+                    </dl>
+                @endif
+                @if(isset($data['relationship']) && !empty($data['relationship']) )
+                    <dl class="dl-horizontal">
+                        <dt>Relationship Status</dt>
+                        <dd>{{ $data['relationship'] }}</dd>
+                    </dl>
+                @endif
+            </div>
+        </div>
+    </div>
+
+    <div class="pmb-block">
+        <div class="pmbb-header">
+            <h2><i class="zmdi zmdi-phone m-r-10"></i> Contact Information</h2>
+        </div>
+        <div class="pmbb-body p-l-30">
+            <div class="pmbb-view">
+                @if(isset($data['phone']) && strlen($data['phone']))
+                    <dl class="dl-horizontal">
+                        <dt>Mobile Phone</dt>
+                        <dd>{{ $data['phone'] }}</dd>
+                    </dl>
+                @endif
+                <dl class="dl-horizontal">
+                    <dt>Email Address</dt>
+                    <dd>{{ $data['email'] }}</dd>
+                </dl>
+                @if(isset($data['twitter']) && strlen($data['twitter']))
+                    <dl class="dl-horizontal">
+                        <dt>Twitter</dt>
+                        <dd><a href="http://twitter.com/{{ $data['twitter'] }}" target="_blank">{{ '@' . $data['twitter'] }}</a></dd>
+                    </dl>
+                @endif
+                @if(isset($data['facebook']) && strlen($data['facebook']))
+                    <dl class="dl-horizontal">
+                        <dt>Facebook</dt>
+                        <dd><a href="http://facebook.com/{{ $data['facebook'] }}" target="_blank">{{ $data['facebook'] }}</a></dd>
+                    </dl>
+                @endif
+                @if(isset($data['github']) && strlen($data['github']))
+                    <dl class="dl-horizontal">
+                        <dt>GitHub</dt>
+                        <dd><a href="http://github.com/{{ $data['github'] }}" target="_blank">{{ $data['github'] }}</a></dd>
+                    </dl>
+                @endif
+                @if(isset($data['address']) && !empty($data['address']))
+                    <dl class="dl-horizontal">
+                        <dt>Address</dt>
+                        <dd>{{ $data['address'] }}</dd>
+                    </dl>
+                @endif
+                @if(isset($data['city']) && !empty($data['city']))
+                    <dl class="dl-horizontal">
+                        <dt>City</dt>
+                        <dd>{{ $data['city'] }}</dd>
+                    </dl>
+                @endif
+                @if(isset($data['country']) && !empty($data['country']))
+                    <dl class="dl-horizontal">
+                        <dt>Country</dt>
+                        <dd>{{ $data['country'] }}</dd>
+                    </dl>
+                @endif
+            </div>
+        </div>
+    </div>
 @stop

--- a/resources/views/backend/profile/layout.blade.php
+++ b/resources/views/backend/profile/layout.blade.php
@@ -1,0 +1,50 @@
+@extends('backend.layout')
+
+@section('title')
+    <title>{{ config('blog.title') }} | Edit Profile</title>
+@stop
+
+@section('content')
+    <section id="main">
+
+        @include('backend.partials.sidebar-navigation')
+
+        <section id="content">
+            <div class="container container-alt">
+
+                <div class="block-header">
+                    <h2>{{ Auth::user()->display_name }}
+                        <small>{{ Auth::user()->job }}, {{ Auth::user()->city }}, {{ Auth::user()->country }}</small>
+                    </h2>
+                </div>
+
+                <div class="card" id="profile-main">
+
+                    @include('backend.profile.partials.sidebar')
+
+                    <div class="pm-body clearfix">
+                        @section('profile-content')
+                            <ul class="tab-nav tn-justified">
+                                <li class="{{Route::is('admin.profile.index') ? 'active' : ''}}">
+                                    <a href="/admin/profile">Profile</a>
+                                </li>
+                                <li class="{{Route::is('admin.profile.edit') ? 'active' : ''}}">
+                                    <a href="/admin/profile/{{ Auth::id() }}/edit">Settings</a>
+                                </li>
+                            </ul>
+
+                            @if(Session::has('errors') || Session::has('success'))
+                                <div class="pmb-block">
+                                    <div class="pmbb-header">
+                                        @include('shared.errors')
+                                        @include('shared.success')
+                                    </div>
+                                </div>
+                            @endif
+                        @show
+                    </div>
+                </div>
+            </div>
+        </section>
+    </section>
+@stop

--- a/resources/views/backend/profile/layout.blade.php
+++ b/resources/views/backend/profile/layout.blade.php
@@ -1,7 +1,7 @@
 @extends('backend.layout')
 
 @section('title')
-    <title>{{ config('blog.title') }} | Edit Profile</title>
+    <title>{{ config('blog.title') }} | Profile</title>
 @stop
 
 @section('content')
@@ -30,6 +30,9 @@
                                 </li>
                                 <li class="{{Route::is('admin.profile.edit') ? 'active' : ''}}">
                                     <a href="/admin/profile/{{ Auth::id() }}/edit">Settings</a>
+                                </li>
+                                <li class="{{Route::is('admin.profile.privacy') ? 'active' : ''}}">
+                                    <a href="/admin/profile/privacy">Privacy</a>
                                 </li>
                             </ul>
 

--- a/resources/views/backend/profile/privacy.blade.php
+++ b/resources/views/backend/profile/privacy.blade.php
@@ -1,0 +1,19 @@
+@extends('backend.profile.layout')
+
+@section('title')
+    <title>{{ config('blog.title') }} | Edit Privacy</title>
+@stop
+
+@section('profile-content')
+  @parent
+
+  <div class="pmb-block">
+      <div class="pmbb-header">
+          <h2><i class="zmdi zmdi-shield-security m-r-10"></i> Change Password</h2>
+      </div>
+
+      <div class="pmbb-body p-l-30">
+          @include('backend.profile.partials.form.password')
+      </div>
+  </div>
+@stop


### PR DESCRIPTION
Adds a new tab to the profile screen for privacy settings, currently only houses the password update form.

<img width="1145" alt="screen shot 2016-07-10 at 11 24 45 pm" src="https://cloud.githubusercontent.com/assets/2295675/16719186/af798d3e-46f5-11e6-9adb-35e75000e846.png">

@austintoddj We could probably simplify a good bit of logic for the profile screens since it will always be using the current user, I can give it a go if you want just let me know.