### PR TITLE
Edited some date getters and also made trim width a setting

### DIFF
--- a/app/Http/Controllers/Backend/PostController.php
+++ b/app/Http/Controllers/Backend/PostController.php
@@ -11,8 +11,6 @@ use App\Http\Requests\PostUpdateRequest;
 
 class PostController extends Controller
 {
-    const TRIM_WIDTH = 40;
-    const TRIM_MARKER = "...";
 
     /**
      * Display a listing of the posts
@@ -22,10 +20,6 @@ class PostController extends Controller
     public function index()
     {
         $data = Post::all();
-
-        foreach ($data as $post) {
-            $post->subtitle = mb_strimwidth($post->subtitle, 0, self::TRIM_WIDTH, self::TRIM_MARKER);
-        }
 
         return view('backend.post.index', compact('data'));
     }

--- a/config/blog.php
+++ b/config/blog.php
@@ -48,4 +48,5 @@ return [
     'webpath'       => '/uploads/',
   ],
 
+  'trim_width'  => 40,
 ];

--- a/resources/views/backend/post/edit.blade.php
+++ b/resources/views/backend/post/edit.blade.php
@@ -37,7 +37,7 @@
 
                         <h2>
                             Edit <em>{{ $title }}</em>
-                            <small>Last edited on {{ \Carbon\Carbon::createFromFormat('Y-m-d H:i:s', $updated_at)->format('M d, Y') }} at {{ \Carbon\Carbon::createFromFormat('Y-m-d H:i:s', $updated_at)->format('g:i A') }}</small>
+                            <small>Last edited on {{ $updated_at->format('M d, Y') }} at {{ $updated_at->format('g:i A') }}</small>
                         </h2>
 
                     </div>

--- a/resources/views/backend/post/index.blade.php
+++ b/resources/views/backend/post/index.blade.php
@@ -56,9 +56,9 @@
                                     <tr>
                                         <td>{{ $post->id }}</td>
                                         <td>{{ $post->title }}</td>
-                                        <td>{{ $post->subtitle }}</td>
+                                        <td>{{ str_limit($post->subtitle, config('blog.trim_width')) }}</td>
                                         <td>{{ $post->slug }}</td>
-                                        <td>{{ \Carbon\Carbon::createFromFormat('Y-m-d H:i:s', $post->published_at)->format('M d, Y') }}</td>
+                                        <td>{{ $post->published_at->format('M d, Y') }}</td>
                                     </tr>
                                 @endforeach
                             </tbody>

--- a/resources/views/backend/tag/edit.blade.php
+++ b/resources/views/backend/tag/edit.blade.php
@@ -38,10 +38,10 @@
                         <h2>
                             Edit <em>{{ $data['title'] }}</em>
                             <small>
-                                @if(isset($updated_at))
-                                    Last edited on {{ \Carbon\Carbon::createFromFormat('Y-m-d H:i:s', $data['$updated_at'])->format('M d, Y') }} at {{ \Carbon\Carbon::createFromFormat('Y-m-d H:i:s', $data['$updated_at'])->format('g:i A') }}
+                                @if(isset($data['updated_at']))
+                                    Last edited on {{$data['updated_at']->format('M d, Y') }} at {{ $data['updated_at']->format('g:i A') }}
                                 @else
-                                    Last edited on {{ \Carbon\Carbon::createFromFormat('Y-m-d H:i:s', $data['created_at'])->format('M d, Y') }} at {{ \Carbon\Carbon::createFromFormat('Y-m-d H:i:s', $data['created_at'])->format('g:i A') }}
+                                    Last edited on {{ $data['created_at']->format('M d, Y') }} at {{ $data['created_at']->format('g:i A') }}
                                 @endif
                             </small>
                         </h2>


### PR DESCRIPTION
In Laravel created_at and updated_at fields are automatically converted to Carbon instances as well as fields that are specified inside protected property $dates inside the model. Here are the [docs](https://laravel.com/docs/5.2/eloquent-mutators#date-mutators). 

So I decided to remove some redundant code, so it would be more readable. Also there was a mistype in /edit.blade.php and it was $data['$updated_at']  (note that $ in front of updated_at). I also corrected that. 

Also I changed another code that is related to trim_width. I thought that instead of manually modifying each model, we can just use a Laravel helper in the view (another option would be to write a specific getter inside the Post model like getTrimmedSubtitle() which is also good, because that way it could be reusable). 