### PR TITLE
corrected z-index

### DIFF
--- a/public/css/app-1.css
+++ b/public/css/app-1.css
@@ -10381,7 +10381,7 @@ h6 small,
   -ms-user-select: none;
   user-select: none;
   position: fixed;
-  z-index: 9999;
+  z-index: 999;
   width: 100%;
   left: 0;
   top: 0;

--- a/resources/assets/css/app-1.css
+++ b/resources/assets/css/app-1.css
@@ -10381,7 +10381,7 @@ h6 small,
   -ms-user-select: none;
   user-select: none;
   position: fixed;
-  z-index: 9999;
+  z-index: 999;
   width: 100%;
   left: 0;
   top: 0;


### PR DESCRIPTION
reduced the z-index to the admin navbar to 999 instead of 9999 as it was covering the modal when launched.  Please see issue #100 for screenshot of issue.