### PR TITLE
Avoided throwing exception when there is no post.index file

### DIFF
--- a/app/Http/Controllers/Backend/ToolsController.php
+++ b/app/Http/Controllers/Backend/ToolsController.php
@@ -25,7 +25,7 @@ class ToolsController extends Controller
         $status = App::isDownForMaintenance() ? 'Maintenance Mode' : 'Active';
 
         $data = [
-            'indexModified'     => filemtime(storage_path('posts.index')),
+            'indexModified'     => file_exists(storage_path('posts.index')) ? filemtime(storage_path('posts.index')) : false,
             'host'              => $_SERVER['HTTP_HOST'],
             'ip'                => $_SERVER['REMOTE_ADDR'],
             'timezone'          => $_SERVER['APP_TIMEZONE'],

--- a/resources/views/backend/tools/index.blade.php
+++ b/resources/views/backend/tools/index.blade.php
@@ -78,14 +78,16 @@
                 <div class="card">
                     <div class="card-header">
                         <h2>Search Index
-                            <small>Last run on {{ date('M d, Y', $data['indexModified']) }}
-                                at {{ date('g:i A', $data['indexModified']) }}</small>
-                            <small>Here you can manually re-run a full index of the posts and tags currently in the
-                                system.
-                                This will trigger an overwrite of the existing index, replacing the data and forcing the
-                                system to rebuild.
-                            </small>
+                        @if ($data['indexModified'])
+                            <small>Last run on {{ date('M d, Y', $data['indexModified']) }} at {{ date('g:i A', $data['indexModified']) }}</small>
+                        @endif
+                            <div>
+                                <small>Here you can manually run a full index of the posts and tags currently in the system.</small>
+                            </div>
                         </h2>
+                        <div class="alert alert-danger" style="margin: 1em 0;">
+                            This will trigger an overwrite of the existing index, replacing the data and forcing the system to rebuild.
+                        </div>
                     </div>
                     <div class="card-body card-padding">
                         <a>


### PR DESCRIPTION
Showing the last modified index **only** when a file exists

In order to prevent to the user, the behavior of `reset index` is displayed in a **danger alert.**