### PR TITLE
Fixed: Keep open datetime-picker in birthday field

### DIFF
--- a/resources/views/backend/shared/components/datetime-picker.blade.php
+++ b/resources/views/backend/shared/components/datetime-picker.blade.php
@@ -2,7 +2,8 @@
   (function(){
     $('.datetime-picker').datetimepicker({
         format: '{{ $format or "YYYY-MM-DD HH:mm:ss" }}',
-        defaultDate: Date.now()
+        defaultDate: Date.now(),
+        keepOpen: true
     });
   })()
 </script>


### PR DESCRIPTION
**Datetimepicker** is forced to remain open even when the time component is not used.

Referenced to @austintoddj [comment](https://github.com/austintoddj/canvas/issues/122#issuecomment-239673893) in #122 