### PR TITLE
Fixed issue #145 route /auth/login

### DIFF
--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -23,7 +23,7 @@ class AuthController extends Controller
     */
     use AuthenticatesUsers, ThrottlesLogins;
 
-    protected $redirectAfterLogout = 'auth/login';
+    protected $redirectAfterLogout = 'admin';
 
     protected $redirectTo = 'admin';
 

--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -38,7 +38,7 @@ class Authenticate
             if ($request->ajax()) {
                 return response('Unauthorized.', 401);
             } else {
-                return redirect()->guest('auth/login');
+                return view('auth.login');
             }
         }
 

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -61,7 +61,6 @@ $router->group([
     'prefix'    => 'auth',
 ], function () {
     // Login
-    Route::get('login', 'AuthController@getLogin');
     Route::post('login', 'AuthController@postLogin');
 
     // Logout

--- a/tests/Functional/AuthenticationTest.php
+++ b/tests/Functional/AuthenticationTest.php
@@ -34,7 +34,7 @@ class AuthenticationTest extends TestCase
      */
     public function testApplicationLogin()
     {
-        $this->visit('/auth/login')
+        $this->visit('/admin')
              ->type($this->user->email, 'email')
              ->type('password', 'password')
              ->press('submit')
@@ -52,7 +52,7 @@ class AuthenticationTest extends TestCase
         $this->actingAs($this->user)
              ->visit('/admin')
              ->click('logout')
-             ->seePageis('/auth/login')
+             ->seePageis('/admin')
              ->dontSeeIsAuthenticated();
     }
 }

--- a/tests/Routes/PublicRoutesTest.php
+++ b/tests/Routes/PublicRoutesTest.php
@@ -46,7 +46,7 @@ class PublicRoutesTest extends TestCase
      */
     public function testLoginPageResponseCode()
     {
-        $response = $this->call('GET', '/auth/login');
+        $response = $this->call('GET', '/admin');
         $this->assertEquals(200, $response->status());
     }
 


### PR DESCRIPTION
I suggest something. I've updated the auth middleware; if the user is authenticated OK, else, instead of redirecting to /auth/login route, I return the auth.login view. So if the user enters /admin, the route stay but the view changes. This can be apply on all authenticated routes