### PR TITLE
Use erikgall/eloquent-phpunit ~1.0 instead of dev-master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "fzaninotto/faker": "~1.4",
         "mockery/mockery": "0.9.*",
         "phpunit/phpunit": "~5.0",
-        "erikgall/eloquent-phpunit": "^1.0"
+        "erikgall/eloquent-phpunit": "~1.0"
     },
     "autoload": {
         "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "fzaninotto/faker": "~1.4",
         "mockery/mockery": "0.9.*",
         "phpunit/phpunit": "~5.0",
-        "erikgall/eloquent-phpunit": "dev-master"
+        "erikgall/eloquent-phpunit": "^1.0"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
I should have done this before when we brought in the package, but I changed the version requirement for the package from dev-master to ~1.0. This way composer won't update the package on every commit and only when the eloquent-phpunit package is tagged.

Erik