### PR TITLE
Document APP_ENV value for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ Before you proceed make sure your server meets the following requirements:
 
 2. Run `composer install` from the command line in the project root.
 3. Run `php artisan storage:link` to link the `storage/app/public` folder to `public/storage` 
-4. Copy the contents of `.env.example` and create a new file called `.env` in the project root. Set your application variables in the new file.
+4. Copy the contents of `.env.example` and create a new file called `.env` in the project root. Set your application variables in the new file. Be sure to keep the value of `APP_ENV` set to `local` for the duration of the install.
 5. Run `php artisan canvas:install` and follow the on-screen prompts.
 7. Run `chmod -R 777 storage/` to change the permissions of the `storage/` directory.
 8. Run `npm install` from the command line in the project root.
+9. Open `.env` again, and change the value of `APP_ENV` to `production`.
 9. Sign in to your new blog at `http://MY_NEW_BLOG.com/admin`
     * Email: `admin@canvas.com`
     * Password: `password`


### PR DESCRIPTION
I discovered through trial and error that if `APP_ENV` is not set to `local` when you run `php artisan canvas:install`, the database creation process will hang, but no error will be given. This commit updates the documentation to clarify what the value of `APP_ENV` should be.