### PR TITLE
Provide canvas version setting

### DIFF
--- a/app/Console/Commands/Install.php
+++ b/app/Console/Commands/Install.php
@@ -102,6 +102,7 @@ class Install extends Command
         $this->disqus();
         $this->googleAnalytics();
         $this->twitterCardType();
+        $this->canvasVersion();
         $this->progress(5);
 
         $this->line(PHP_EOL.'<info>✔</info> Canvas has been successfully installed! Happy blogging!'.PHP_EOL);
@@ -199,6 +200,13 @@ class Install extends Command
         $settings = new Settings();
         $settings->setting_name = 'twitter_card_type';
         $settings->setting_value = 'none';
+        $settings->save();
+    }
+
+    private function canvasVersion() {
+        $settings = new Settings();
+        $settings->setting_name = 'canvas_version';
+        $settings->setting_value = '2.1.7';
         $settings->save();
     }
 }

--- a/app/Http/Controllers/Backend/SettingsController.php
+++ b/app/Http/Controllers/Backend/SettingsController.php
@@ -34,6 +34,7 @@ class SettingsController extends Controller
             'db_connection' => strtoupper(env('DB_CONNECTION')),
             'web_server' => $_SERVER['SERVER_SOFTWARE'],
             'last_index' => date('Y-m-d H:i:s', file_exists(storage_path('posts.index')) ? filemtime(storage_path('posts.index')) : false),
+            'version' => Settings::canvasVersion(),
         ];
 
         return view('backend.settings.index', compact('data'));

--- a/app/Models/Settings.php
+++ b/app/Models/Settings.php
@@ -78,6 +78,15 @@ class Settings extends Model
     }
 
     /**
+     * Get the current canvas application version
+     *
+     * return @string
+     */
+     public static function canvasVersion() {
+         return self::getByName('canvas_version');
+     }
+
+    /**
      * Get the value of the Disqus shortname.
      *
      * return @string

--- a/resources/views/backend/settings/partials/system-information.blade.php
+++ b/resources/views/backend/settings/partials/system-information.blade.php
@@ -11,6 +11,8 @@
 
 ## Please include this information when requesting technical support ##
 
+CANVAS_VERSION:             {{ $data['version'] }}
+
 SITE_URL:                   {{ $data['url'] }}
 SITE_IP:                    {{ $data['ip'] }}
 SITE_TIMEZONE:              {{ $data['timezone'] }}


### PR DESCRIPTION
Upon install generate a canvas_version setting key/value in the database so that when viewing the settings page the user can let support know what version is currently being used.