### PR TITLE
If no canvas version in database show older than message

### DIFF
--- a/app/Http/Controllers/Backend/SettingsController.php
+++ b/app/Http/Controllers/Backend/SettingsController.php
@@ -34,7 +34,7 @@ class SettingsController extends Controller
             'db_connection' => strtoupper(env('DB_CONNECTION')),
             'web_server' => $_SERVER['SERVER_SOFTWARE'],
             'last_index' => date('Y-m-d H:i:s', file_exists(storage_path('posts.index')) ? filemtime(storage_path('posts.index')) : false),
-            'version' => Settings::canvasVersion(),
+            'version' => (!empty(Settings::canvasVersion())) ? Settings::canvasVersion() : 'Older than v2.1.7',
         ];
 
         return view('backend.settings.index', compact('data'));


### PR DESCRIPTION
If the database can't find the canvas version then show 'Older than 2.1.7' so we at least have some sort of constructive feedback.