### PR TITLE
Fix #217 - Deleting a post test

### DIFF
--- a/tests/Models/PostTest.php
+++ b/tests/Models/PostTest.php
@@ -145,13 +145,10 @@ class PostTest extends EloquentTestCase
      */
     public function testPostsCanBeDeleted()
     {
-        // TODO : The UI/UX works in the browser, but the following test code always fails.
-//        $this->callRouteAsUser('admin.post.edit', 1)
-//            ->press('Delete')
-//            ->dontSee($this->getDeleteMessage())
-//            ->press('Delete Post')
-//            ->see($this->getDeleteMessage())
-//            ->dontSeePostInDatabase(1);
+       $this->callRouteAsUser('admin.post.edit', 1)
+           ->press('Delete Post')
+           ->see($this->getDeleteMessage())
+           ->dontSeePostInDatabase(1);
     }
 
     /**

--- a/tests/Models/PostTest.php
+++ b/tests/Models/PostTest.php
@@ -145,10 +145,10 @@ class PostTest extends EloquentTestCase
      */
     public function testPostsCanBeDeleted()
     {
-       $this->callRouteAsUser('admin.post.edit', 1)
-           ->press('Delete Post')
-           ->see($this->getDeleteMessage())
-           ->dontSeePostInDatabase(1);
+        $this->callRouteAsUser('admin.post.edit', 1)
+             ->press('Delete Post')
+             ->see($this->getDeleteMessage())
+             ->dontSeePostInDatabase(1);
     }
 
     /**


### PR DESCRIPTION
# Issue #217

You cannot interact with Javascript using PHPUnit/Laravel's testing helpers that simulate browser events. Calling methods such as `see(...)`, `press(...)`, `click(...)`  do nothing more than scan the HTML output sent by Laravel to the browser, checking if it exists and simulating whatever that actions is like following a link to the href attribute..

The test was failing because you were pressing a button containing the string "delete" followed by pressing a button containing the string "delete post.." Since you cannot interact with the page's JS using PHPUnit/Laravel's default testing setup, the form was being submitted on the first `$this->press('delete')`.



