### PR TITLE
Move report generation to within the tests folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 /node_modules
 /storage/*.index
 /public/storage
-/report
+/tests/report
 
 Thumbs.db
 composer.lock

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,9 +20,9 @@
         </whitelist>
     </filter>
     <logging>
-        <log type="coverage-html" target="report" lowUpperBound="35" highLowerBound="70"/>
-        <log type="testdox-html" target="report/testdox.html"/>
-        <log type="testdox-text" target="report/testdox.txt"/>
+        <log type="coverage-html" target="tests/report" lowUpperBound="35" highLowerBound="70"/>
+        <log type="testdox-html" target="tests/report/testdox.html"/>
+        <log type="testdox-text" target="tests/report/testdox.txt"/>
     </logging>
     <php>
         <env name="APP_ENV" value="testing"/>


### PR DESCRIPTION
All testing material is now contained within the same folder.