### PR TITLE
Fix empty UI if the app uses an unsupported language

### DIFF
--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -70,7 +70,10 @@ class UserController extends Controller
             }
         }
 
-        if (! in_array($data['locale'], Canvas::availableLanguageCodes())) {
+        if (
+            ! isset($data['locale'])
+            || ! in_array($data['locale'], Canvas::availableLanguageCodes())
+        ) {
             $data['locale'] = 'en';
         }
 

--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -70,10 +70,7 @@ class UserController extends Controller
             }
         }
 
-        if (
-            ! isset($data['locale'])
-            || ! in_array($data['locale'], Canvas::availableLanguageCodes())
-        ) {
+        if (! in_array($data['locale'], Canvas::availableLanguageCodes())) {
             $data['locale'] = 'en';
         }
 

--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -71,8 +71,8 @@ class UserController extends Controller
         }
 
         if (
-            ! isset($data['locale'])
-            || ! in_array($data['locale'], Canvas::availableLanguageCodes())
+            ! Arr::has($data, 'locale')
+            || ! Arr::has(Canvas::availableLanguageCodes(), $data['locale'])
         ) {
             $data['locale'] = 'en';
         }

--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -2,6 +2,7 @@
 
 namespace Canvas\Http\Controllers;
 
+use Canvas\Canvas;
 use Canvas\Http\Requests\UserRequest;
 use Canvas\Models\User;
 use Exception;
@@ -67,6 +68,13 @@ class UserController extends Controller
                     'id' => $id,
                 ]);
             }
+        }
+
+        if (
+            ! isset($data['locale'])
+            || ! in_array($data['locale'], Canvas::availableLanguageCodes())
+        ) {
+            $data['locale'] = 'en';
         }
 
         $user->fill($data);


### PR DESCRIPTION
It seems using an unsupported locale on the Laravel installation, creates an entirely blank UI when visited.

![Screenshot 2020-11-16 at 23 57 42](https://user-images.githubusercontent.com/2234034/99320578-412d5100-286c-11eb-817c-041dad40c258.png)
![Screenshot 2020-11-16 at 23 57 54](https://user-images.githubusercontent.com/2234034/99320596-4a1e2280-286c-11eb-88ae-bf4c4a8a687b.png)
![Screenshot 2020-11-16 at 23 58 04](https://user-images.githubusercontent.com/2234034/99320608-50140380-286c-11eb-8089-bb1ff8879ad6.png)


Which won't be alleviated until the user has blindly navigated to the settings > locale options and set another locale, when this happens, everything works as expected.

Our app runs Danish pr. default with a fallback to english, but since Danish isn't supported by Canvas yet, Canvas tries to show a bunch on non-existent strings.

![Screenshot 2020-11-16 at 23 58 09](https://user-images.githubusercontent.com/2234034/99320646-628e3d00-286c-11eb-9e5d-cd54eeed9326.png)


This PR. aims to alleviate it by defaulting to the english locale, in case no locale is given, and the app-locale is not supported.