### PR TITLE
[WIP] Deduce visits from views (#891)

### DIFF
--- a/src/Services/StatsAggregatorService.php
+++ b/src/Services/StatsAggregatorService.php
@@ -39,12 +39,13 @@ class StatsAggregatorService
                          today()->endOfDay()->toDateTimeString(),
                      ])->get();
 
-        $visits = Visit::select('created_at')
-                       ->whereIn('post_id', $posts->pluck('id'))
-                       ->whereBetween('created_at', [
-                           today()->subDays($days)->startOfDay()->toDateTimeString(),
-                           today()->endOfDay()->toDateTimeString(),
-                       ])->get();
+        $visits = View::selectRaw('ip, agent, DATE(created_at) as created_at')
+                     ->whereIn('post_id', $posts->pluck('id'))
+                     ->distinct('ip, agent, day')
+                     ->whereBetween('created_at', [
+                         today()->subDays($days)->startOfDay()->toDateTimeString(),
+                         today()->endOfDay()->toDateTimeString(),
+                     ])->get();
 
         return [
             'totalViews' => $views->count(),


### PR DESCRIPTION
Hi,

I marked this as WIP to allow you to play around with it, and see how it works, before we settle on a way to implement it.

Basically it discards the entire `visits` table, and uses the `views` to deduce views.

Views are grouped by Ip, user-agent string and the current date. Meaning one user can create multiple views by jumping IPs, using different browsers or visiting on different days.

I believe the existing setup counts visits the same way, but simply relies on what's in the `visits` table. which can be manipulated by manually removing the Laravel Session, IE. by going Incognito or clearing cookies.

Mainly, this proves to an advantage for users who use Laravel as an API with a separate frontend. See #891 