### PR TITLE
Update ShowPost.vue

### DIFF
--- a/resources/js/ui/views/ShowPost.vue
+++ b/resources/js/ui/views/ShowPost.vue
@@ -199,7 +199,7 @@ export default {
 
     beforeRouteLeave(to, from, next) {
         // Hack to remove the canonical tag when you navigate away
-        document.querySelector('link[rel="canonical"]').remove();
+        document.querySelector('link[rel="canonical"]')?.remove();
         next();
     },
 


### PR DESCRIPTION
When canonical url is missing, there is an error when trying to remove link rel canonical.
This fix the issue.