### PR TITLE
Fix change language

### DIFF
--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -71,7 +71,7 @@ class UserController extends Controller
             }
         }
 
-        if (! Arr::has($data, 'locale') || ! Arr::has(Canvas::availableLanguageCodes(), $data['locale'])) {
+        if (! Arr::has($data, 'locale') || ! in_array($data['locale'], Canvas::availableLanguageCodes())) {
             $data['locale'] = config('app.fallback_locale');
         }
 


### PR DESCRIPTION
If you try to change language in settings, it doesn't work. Because it's being used `Arr:has()` which check for key in array, while `Canvas::availableLanguageCodes()` return an non-associative array, with index as key and not language code. So we can just use `in_array()` function.