### PR TITLE
Ability to use a dedicated Canvas database connection

### DIFF
--- a/config/canvas.php
+++ b/config/canvas.php
@@ -4,6 +4,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Canvas Database Connection
+    |--------------------------------------------------------------------------
+    |
+    | This is the database connection you want Canvas to use while storing &
+    | reading your content. By default Canvas uses the default one. However, you can change that
+    | to anything you want.
+    |
+    */
+
+    'database_connection' => env('CANVAS_DB_CONNECTION', 'mysql'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Base Domain
     |--------------------------------------------------------------------------
     |

--- a/database/migrations/2020_09_21_000000_create_canvas_tables.php
+++ b/database/migrations/2020_09_21_000000_create_canvas_tables.php
@@ -62,7 +62,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create(self::USERS_TABLE, function (Blueprint $table) {
+        Schema::connection(config('canvas.database_connection'))->create(self::USERS_TABLE, function (Blueprint $table) {
             $table->uuid('id')->primary();
             $table->string('name');
             $table->string('email')->unique();
@@ -84,7 +84,7 @@ return new class extends Migration
             $table->softDeletes();
         });
 
-        Schema::create(self::TAGS_TABLE, function (Blueprint $table) {
+        Schema::connection(config('canvas.database_connection'))->create(self::TAGS_TABLE, function (Blueprint $table) {
             $table->uuid('id')->primary();
             $table->string('slug');
             $table->string('name');
@@ -99,7 +99,7 @@ return new class extends Migration
             $table->unique(['slug', 'user_id']);
         });
 
-        Schema::create(self::TOPICS_TABLE, function (Blueprint $table) {
+        Schema::connection(config('canvas.database_connection'))->create(self::TOPICS_TABLE, function (Blueprint $table) {
             $table->uuid('id')->primary();
             $table->string('slug');
             $table->string('name');
@@ -114,7 +114,7 @@ return new class extends Migration
             $table->unique(['slug', 'user_id']);
         });
 
-        Schema::create(self::POSTS_TABLE, function (Blueprint $table) {
+        Schema::connection(config('canvas.database_connection'))->create(self::POSTS_TABLE, function (Blueprint $table) {
             $table->uuid('id')->primary();
             $table->string('slug');
             $table->string('title');
@@ -132,14 +132,14 @@ return new class extends Migration
             $table->unique(['slug', 'user_id']);
         });
 
-        Schema::create(self::POSTS_TAGS_TABLE, function (Blueprint $table) {
+        Schema::connection(config('canvas.database_connection'))->create(self::POSTS_TAGS_TABLE, function (Blueprint $table) {
             $table->foreignUuid('post_id')->index()->references('id')->on(self::POSTS_TABLE);
             $table->foreignUuid('tag_id')->index()->references('id')->on(self::TAGS_TABLE);
 
             $table->unique(['post_id', 'tag_id']);
         });
 
-        Schema::create(self::VIEWS_TABLE, function (Blueprint $table) {
+        Schema::connection(config('canvas.database_connection'))->create(self::VIEWS_TABLE, function (Blueprint $table) {
             $table->increments('id');
             $table->foreignUuid('post_id')->index()->references('id')->on(self::POSTS_TABLE);
             $table->string('ip')->nullable();
@@ -150,7 +150,7 @@ return new class extends Migration
             $table->index('created_at');
         });
 
-        Schema::create(self::VISITS_TABLE, function (Blueprint $table) {
+        Schema::connection(config('canvas.database_connection'))->create(self::VISITS_TABLE, function (Blueprint $table) {
             $table->increments('id');
             $table->foreignUuid('post_id')->references('id')->on(self::POSTS_TABLE);
             $table->string('ip')->nullable();
@@ -169,12 +169,12 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists(self::USERS_TABLE);
-        Schema::dropIfExists(self::TAGS_TABLE);
-        Schema::dropIfExists(self::TOPICS_TABLE);
-        Schema::dropIfExists(self::POSTS_TABLE);
-        Schema::dropIfExists(self::POSTS_TAGS_TABLE);
-        Schema::dropIfExists(self::VIEWS_TABLE);
-        Schema::dropIfExists(self::VISITS_TABLE);
+        Schema::connection(config('canvas.database_connection'))->dropIfExists(self::USERS_TABLE);
+        Schema::connection(config('canvas.database_connection'))->dropIfExists(self::TAGS_TABLE);
+        Schema::connection(config('canvas.database_connection'))->dropIfExists(self::TOPICS_TABLE);
+        Schema::connection(config('canvas.database_connection'))->dropIfExists(self::POSTS_TABLE);
+        Schema::connection(config('canvas.database_connection'))->dropIfExists(self::POSTS_TAGS_TABLE);
+        Schema::connection(config('canvas.database_connection'))->dropIfExists(self::VIEWS_TABLE);
+        Schema::connection(config('canvas.database_connection'))->dropIfExists(self::VISITS_TABLE);
     }
 };

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -32,5 +32,6 @@
         <env name="APP_ENV" value="testing"/>
         <env name="APP_KEY" value="base64:cnx7anOUDil+KtEGdGiHBnY764aA05eU80oECtOqfYs="/>
         <env name="APP_URL" value="http://laravel.test"/>
+        <env name="CANVAS_DB_CONNECTION" value="sqlite"/>
     </php>
 </phpunit>

--- a/src/Console/MigrateCommand.php
+++ b/src/Console/MigrateCommand.php
@@ -30,6 +30,7 @@ class MigrateCommand extends Command
     public function handle()
     {
         $this->callSilent('migrate', [
+            '--database' => config('canvas.database_connection'),
             '--path' => 'vendor/austintoddj/canvas/database/migrations',
             '--force' => $this->option('force') ?? true,
         ]);

--- a/src/Http/Requests/AuthenticatedSessionRequest.php
+++ b/src/Http/Requests/AuthenticatedSessionRequest.php
@@ -29,8 +29,10 @@ class AuthenticatedSessionRequest extends FormRequest
     {
         $this->redirect = route('canvas.login.view');
 
+        $connection = config('canvas.database_connection');
+
         return [
-            'email' => 'required|email:filter|exists:canvas_users',
+            'email' => "required|email:filter|exists:{$connection}.canvas_users",
             'password' => 'required',
         ];
     }

--- a/src/Http/Requests/NewPasswordRequest.php
+++ b/src/Http/Requests/NewPasswordRequest.php
@@ -25,9 +25,11 @@ class NewPasswordRequest extends FormRequest
      */
     public function rules()
     {
+        $connection = config('canvas.database_connection');
+
         return [
             'token' => 'required',
-            'email' => 'required|email:filter|exists:canvas_users',
+            'email' => "required|email:filter|exists:{$connection}.canvas_users",
             'password' => 'required|confirmed|min:8',
         ];
     }

--- a/src/Http/Requests/PasswordResetLinkRequest.php
+++ b/src/Http/Requests/PasswordResetLinkRequest.php
@@ -25,8 +25,10 @@ class PasswordResetLinkRequest extends FormRequest
      */
     public function rules()
     {
+        $connection = config('canvas.database_connection');
+
         return [
-            'email' => 'required|email:filter|exists:canvas_users',
+            'email' => "required|email:filter|exists:{$connection}.canvas_users",
         ];
     }
 

--- a/src/Http/Requests/StorePostRequest.php
+++ b/src/Http/Requests/StorePostRequest.php
@@ -34,11 +34,13 @@ class StorePostRequest extends FormRequest
      */
     public function rules()
     {
+        $connection = config('canvas.database_connection');
+
         return [
             'slug' => [
                 'required',
                 'alpha_dash',
-                Rule::unique('canvas_posts')->where(function (Builder $query) {
+                Rule::unique("{$connection}.canvas_posts")->where(function (Builder $query) {
                     return $query->where('slug', request('slug'))->where('user_id', request()->user('canvas')->id);
                 })->ignore($this->route('id'))->whereNull('deleted_at'),
             ],

--- a/src/Http/Requests/StoreTagRequest.php
+++ b/src/Http/Requests/StoreTagRequest.php
@@ -27,12 +27,14 @@ class StoreTagRequest extends FormRequest
      */
     public function rules()
     {
+        $connection = config('canvas.database_connection');
+
         return [
             'name' => 'required|string',
             'slug' => [
                 'required',
                 'alpha_dash',
-                Rule::unique('canvas_tags')->where(function (Builder $query) {
+                Rule::unique("{$connection}.canvas_tags")->where(function (Builder $query) {
                     return $query->where('slug', request('slug'))->where('user_id', request()->user('canvas')->id);
                 })->ignore($this->route('id'))->whereNull('deleted_at'),
             ],

--- a/src/Http/Requests/StoreTopicRequest.php
+++ b/src/Http/Requests/StoreTopicRequest.php
@@ -27,12 +27,14 @@ class StoreTopicRequest extends FormRequest
      */
     public function rules()
     {
+        $connection = config('canvas.database_connection');
+
         return [
             'name' => 'required|string',
             'slug' => [
                 'required',
                 'alpha_dash',
-                Rule::unique('canvas_topics')->where(function (Builder $query) {
+                Rule::unique("{$connection}.canvas_topics")->where(function (Builder $query) {
                     return $query->where('slug', request('slug'))->where('user_id', request()->user('canvas')->id);
                 })->ignore($this->route('id'))->whereNull('deleted_at'),
             ],

--- a/src/Http/Requests/StoreUserRequest.php
+++ b/src/Http/Requests/StoreUserRequest.php
@@ -27,19 +27,21 @@ class StoreUserRequest extends FormRequest
      */
     public function rules()
     {
+        $connection = config('canvas.database_connection');
+
         return [
             'name' => 'required|string',
             'email' => [
                 'required',
                 'email:filter',
-                Rule::unique('canvas_users')->where(function (Builder $query) {
+                Rule::unique("{$connection}.canvas_users")->where(function (Builder $query) {
                     return $query->where('email', request('email'));
                 })->ignore($this->route('id'))->whereNull('deleted_at'),
             ],
             'username' => [
                 'nullable',
                 'alpha_dash',
-                Rule::unique('canvas_users')->where(function (Builder $query) {
+                Rule::unique("{$connection}.canvas_users")->where(function (Builder $query) {
                     return $query->where('username', request('username'));
                 })->ignore($this->route('id'))->whereNull('deleted_at'),
             ],

--- a/src/Models/AbstractCanvasModel.php
+++ b/src/Models/AbstractCanvasModel.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Canvas\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+abstract class AbstractCanvasModel extends Model
+{
+    /**
+     * Get the current connection name for the model.
+     *
+     * @return string
+     */
+    public function getConnectionName()
+    {
+        return config('canvas.database_connection');
+    }
+}

--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -7,10 +7,9 @@ namespace Canvas\Models;
 use Canvas\Database\Factories\PostFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
-class Post extends Model
+class Post extends AbstractCanvasModel
 {
     use HasFactory, SoftDeletes;
 

--- a/src/Models/Tag.php
+++ b/src/Models/Tag.php
@@ -6,10 +6,9 @@ namespace Canvas\Models;
 
 use Canvas\Database\Factories\TagFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
-class Tag extends Model
+class Tag extends AbstractCanvasModel
 {
     use HasFactory, SoftDeletes;
 

--- a/src/Models/Topic.php
+++ b/src/Models/Topic.php
@@ -6,10 +6,9 @@ namespace Canvas\Models;
 
 use Canvas\Database\Factories\TopicFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
-class Topic extends Model
+class Topic extends AbstractCanvasModel
 {
     use HasFactory, SoftDeletes;
 

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -7,9 +7,9 @@ namespace Canvas\Models;
 use Canvas\Canvas;
 use Canvas\Database\Factories\UserFactory;
 use Canvas\Traits\HasRole;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Contracts\Auth\Authenticatable;
 
 class User extends AbstractCanvasModel implements Authenticatable
 {

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -9,9 +9,9 @@ use Canvas\Database\Factories\UserFactory;
 use Canvas\Traits\HasRole;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Contracts\Auth\Authenticatable;
 
-class User extends Authenticatable
+class User extends AbstractCanvasModel implements Authenticatable
 {
     use HasFactory, HasRole, SoftDeletes;
 
@@ -167,6 +167,71 @@ class User extends Authenticatable
     public function getDefaultLocaleAttribute()
     {
         return config('app.locale');
+    }
+
+    /**
+     * Get the name of the unique identifier for the user.
+     *
+     * @return string
+     */
+    public function getAuthIdentifierName()
+    {
+        return $this->getKeyName();
+    }
+
+    /**
+     * Get the unique identifier for the user.
+     *
+     * @return mixed
+     */
+    public function getAuthIdentifier()
+    {
+        return $this->{$this->getAuthIdentifierName()};
+    }
+
+    /**
+     * Get the password for the user.
+     *
+     * @return string
+     */
+    public function getAuthPassword()
+    {
+        return $this->password;
+    }
+
+    /**
+     * Get the token value for the "remember me" session.
+     *
+     * @return string|null
+     */
+    public function getRememberToken()
+    {
+        if (! empty($this->getRememberTokenName())) {
+            return (string) $this->{$this->getRememberTokenName()};
+        }
+    }
+
+    /**
+     * Set the token value for the "remember me" session.
+     *
+     * @param  string  $value
+     * @return void
+     */
+    public function setRememberToken($value)
+    {
+        if (! empty($this->getRememberTokenName())) {
+            $this->{$this->getRememberTokenName()} = $value;
+        }
+    }
+
+    /**
+     * Get the column name for the "remember me" token.
+     *
+     * @return string
+     */
+    public function getRememberTokenName()
+    {
+        return $this->rememberTokenName;
     }
 
     /**

--- a/src/Models/View.php
+++ b/src/Models/View.php
@@ -6,9 +6,8 @@ namespace Canvas\Models;
 
 use Canvas\Database\Factories\ViewFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
 
-class View extends Model
+class View extends AbstractCanvasModel
 {
     use HasFactory;
 

--- a/src/Models/Visit.php
+++ b/src/Models/Visit.php
@@ -6,9 +6,8 @@ namespace Canvas\Models;
 
 use Canvas\Database\Factories\VisitFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
 
-class Visit extends Model
+class Visit extends AbstractCanvasModel
 {
     use HasFactory;
 


### PR DESCRIPTION
Pull Request Suggestion linked with Issue #509 

The actual Canvas database connection is the `config('database.default')` . 
In order to use a dedicated database connection. It needed a config parameter to identify it.

config/canvas.php
```
'database_connection' => env('CANVAS_DB_CONNECTION', 'mysql'),
```

It is since then, implemented in the config file, migrations, models [ via a AbstractCanvasModel extended class ], the migrate command, and all the dedicated requests verifying if the table exists.

The config method call is a bit redundant, I confess.


The phpunit tests runs correctly with the `CANVAS_DB_CONNECTION` set to `sqlite` in `phpunit.xml.dist` file as it is the way indicated in the `Contributing` markdown page. 

- I couldn't try to create a post directly from the dashboard using the `develop` branch yet.
- I haven't updated the `readme.md` file explaining the way and use of this feature yet. Waiting for your approval.
- I based my PR on Wink's database connection implementation. 


To make this work in a new laravel project, just follow the `Contributing` page. But before the `php artisan canvas:install` command. Be sure to have these data set : 

.env 
```
CANVAS_DB_CONNECTION={your-canvas-db-connection}
CANVAS_DB_DATABASE=canvas
.
.
.
```


config/database.php [ custom connection, for example here a custom mysql database ]
```
'connections' => [
    {your-canvas-db-connection} => [
            'driver' => 'mysql',
            'url' => env('CANVAS_DATABASE_URL'),
            'host' => env('CANVAS_DB_HOST', '127.0.0.1'),
            'port' => env('CANVAS_DB_PORT', '3306'),
            'database' => env('CANVAS_DB_DATABASE', 'forge'),
            'username' => env('CANVAS_DB_USERNAME', 'forge'),
            'password' => env('CANVAS_DB_PASSWORD', ''),
            'unix_socket' => env('CANVAS_DB_SOCKET', ''),
            'charset' => 'utf8mb4',
            'collation' => 'utf8mb4_unicode_ci',
            'prefix' => '',
            'prefix_indexes' => true,
            'strict' => true,
            'engine' => null,
            'options' => extension_loaded('pdo_mysql') ? array_filter([
                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
            ]) : [],
        ], 
```

Hope this helps.