### PR TITLE
Correction of issue in EmbedImage and FeaturedImage when path is empty

### DIFF
--- a/resources/js/components/editor/EmbedImageModal.vue
+++ b/resources/js/components/editor/EmbedImageModal.vue
@@ -233,7 +233,7 @@ export default {
 
         getServerOptions() {
             return {
-                url: `${this.settings.path}/api/uploads`,
+                url: this.settings.path !== '/' ? `${this.settings.path}/api/uploads` : '/api/uploads',
                 headers: {
                     'X-CSRF-TOKEN': document.head.querySelector('meta[name="csrf-token"]').content,
                 },

--- a/resources/js/components/modals/AvatarModal.vue
+++ b/resources/js/components/modals/AvatarModal.vue
@@ -106,9 +106,9 @@ export default {
         }),
 
         getServerOptions() {
+
             return {
-                // TODO: This check shouldn't need to be here
-                url: this.settings.path === '/' ? `/api/uploads` : `${this.settings.path}/api/uploads`,
+                url: this.settings.path !== '/' ? `${this.settings.path}/api/uploads` : '/api/uploads',
                 headers: {
                     'X-CSRF-TOKEN': document.head.querySelector('meta[name="csrf-token"]').content,
                 },

--- a/resources/js/components/modals/FeaturedImageModal.vue
+++ b/resources/js/components/modals/FeaturedImageModal.vue
@@ -227,7 +227,7 @@ export default {
 
         getServerOptions() {
             return {
-                url: `${this.settings.path}/api/uploads`,
+                url: this.settings.path !== '/' ? `${this.settings.path}/api/uploads` : '/api/uploads',
                 headers: {
                     'X-CSRF-TOKEN': document.head.querySelector('meta[name="csrf-token"]').content,
                 },


### PR DESCRIPTION
Related to issue #1281 

I finally copy pasted the line found in AvatarModal in EmbedImageModal and FeaturedImageModal from the `master` branch obviously, since the `develop` branch will modify the canvas dashboard. I didn't want to modify the part of code that manage the canvas path :

Canvas.php line 97 : 

```
public static function basePath(): string
{
        return sprintf('/%s', config('canvas.path'));
}
```

This always returns : `/` if empty.

Hope this helps
