### PR TITLE
Fix published_at when editing a post

### DIFF
--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -71,7 +71,7 @@ class Post extends Model
      * @var array
      */
     protected $casts = [
-        'published_at' => 'datetime:Y-m-d',
+        'published_at' => 'datetime:Y-m-d H:i:s',
         'meta' => 'array',
     ];
 


### PR DESCRIPTION
When editing a Post, the published_at time is set to 00:00:00.
This fix the problem by keeping the good date time.