### PR TITLE
SEO-Friendly Naming Scheme for Image Uploads with Corresponding Test Cases

### DIFF
--- a/src/Http/Controllers/UploadsController.php
+++ b/src/Http/Controllers/UploadsController.php
@@ -21,14 +21,21 @@ class UploadsController extends Controller
             return response()->json(null, 400);
         }
 
-        // Only grab the first element because single file uploads
-        // are not supported at this time
+        // Only grab the first element because single file uploads are not supported at this time
         $file = reset($payload);
 
-        $path = $file->store(Canvas::baseStoragePath(), [
+        // Generate a unique identifier based on a hash of the original filename
+        $path_parts = pathinfo($file->getClientOriginalName());
+        $first_name = Str::kebab($path_parts['filename']);
+        $unique_id = substr(md5($path_parts['filename']), 0, 8);
+        $filename = $first_name . '-' . $unique_id . '.' . $path_parts['extension'];
+
+        // Store the file using the generated filename
+        $path = $file->storeAs(Canvas::baseStoragePath(), $filename, [
             'disk' => config('canvas.storage_disk'),
         ]);
 
+        // Return the URL of the stored file
         return Storage::disk(config('canvas.storage_disk'))->url($path);
     }
 

--- a/src/Http/Controllers/UploadsController.php
+++ b/src/Http/Controllers/UploadsController.php
@@ -29,7 +29,6 @@ class UploadsController extends Controller
         // Use pathinfo to separate the filename and extension
         $path_parts = pathinfo($file->getClientOriginalName());
 
-        $path_parts = pathinfo($file->getClientOriginalName());
         $first_name = Str::kebab($path_parts['filename']);
         $unique_id = substr(md5($path_parts['filename']), 0, 8);
         

--- a/src/Http/Controllers/UploadsController.php
+++ b/src/Http/Controllers/UploadsController.php
@@ -5,6 +5,7 @@ namespace Canvas\Http\Controllers;
 use Canvas\Canvas;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 
 class UploadsController extends Controller
 {
@@ -21,21 +22,23 @@ class UploadsController extends Controller
             return response()->json(null, 400);
         }
 
-        // Only grab the first element because single file uploads are not supported at this time
+        // Only grab the first element because single file uploads
+        // are not supported at this time
         $file = reset($payload);
 
-        // Generate a unique identifier based on a hash of the original filename
+        // Use pathinfo to separate the filename and extension
+        $path_parts = pathinfo($file->getClientOriginalName());
+
         $path_parts = pathinfo($file->getClientOriginalName());
         $first_name = Str::kebab($path_parts['filename']);
         $unique_id = substr(md5($path_parts['filename']), 0, 8);
-        $filename = $first_name . '-' . $unique_id . '.' . $path_parts['extension'];
+        
+        $name = $first_name . '-' . $unique_id . '.' . $path_parts['extension'];
 
-        // Store the file using the generated filename
-        $path = $file->storeAs(Canvas::baseStoragePath(), $filename, [
+        $path = $file->storeAs(Canvas::baseStoragePath(), $name, [
             'disk' => config('canvas.storage_disk'),
         ]);
 
-        // Return the URL of the stored file
         return Storage::disk(config('canvas.storage_disk'))->url($path);
     }
 

--- a/tests/Http/Controllers/UploadsControllerTest.php
+++ b/tests/Http/Controllers/UploadsControllerTest.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Canvas\Canvas;
 
 /**
  * Class UploadsControllerTest.
@@ -17,37 +18,35 @@ class UploadsControllerTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-        Storage::fake(config('canvas.storage_disk'));
-    }
-
     protected function generateExpectedFilename($file)
     {
         $path_parts = pathinfo($file->getClientOriginalName());
         $first_name = Str::kebab($path_parts['filename']);
         $unique_id = substr(md5($path_parts['filename']), 0, 8);
-        
+
         return $first_name . '-' . $unique_id . '.' . $path_parts['extension'];
     }
 
+
     public function testEmptyUploadIsValidated(): void
     {
+        Storage::fake(config('canvas.storage_disk'));
+
         $this->actingAs($this->admin, 'canvas')
-             ->postJson('canvas/api/uploads', [null])
-             ->assertStatus(400);
+            ->postJson('canvas/api/uploads', [null])
+            ->assertStatus(400);
     }
 
     public function testUploadedImageCanBeStored(): void
     {
+        Storage::fake(config('canvas.storage_disk'));
+
         // Simulate an image upload request
         $file = UploadedFile::fake()->image('sample-image.jpg');
-        
-        // Store the file and check if it was successful
+
         $response = $this->actingAs($this->admin, 'canvas')
-                         ->postJson('canvas/api/uploads', [$file])
-                         ->assertSuccessful();
+            ->postJson('canvas/api/uploads', [$file])
+            ->assertSuccessful();
 
         // Build the expected filename and path
         $expected_filename = $this->generateExpectedFilename($file);
@@ -60,29 +59,35 @@ class UploadsControllerTest extends TestCase
         );
         $this->assertIsString($response->getContent());
         Storage::disk(config('canvas.storage_disk'))->assertExists($expected_path);
+
+        // Now delete the uploaded file and verify it was removed
+        $this->actingAs($this->admin, 'canvas')
+            ->deleteJson('canvas/api/uploads', [$expected_filename])
+            ->assertStatus(204);
+
+        Storage::disk(config('canvas.storage_disk'))->assertExists($expected_path);
     }
 
     public function testDeleteUploadedImage(): void
     {
-        // First, upload a file to delete later
+        Storage::fake(config('canvas.storage_disk'));
+
+        $this->actingAs($this->admin, 'canvas')
+            ->delete('canvas/api/uploads', [
+                null,
+            ])->assertStatus(400);
+
+        // Simulate an image upload request
         $file = UploadedFile::fake()->image('sample-image.jpg');
+
+        // Build the expected filename and path
         $expected_filename = $this->generateExpectedFilename($file);
         $expected_path = sprintf('%s/%s', Canvas::baseStoragePath(), $expected_filename);
 
-        // Store the file
         $this->actingAs($this->admin, 'canvas')
-             ->postJson('canvas/api/uploads', [$file])
-             ->assertSuccessful();
+            ->deleteJson('canvas/api/uploads', [$file])
+            ->assertSuccessful();
 
-        // Ensure the file was uploaded and exists
-        Storage::disk(config('canvas.storage_disk'))->assertExists($expected_path);
-
-        // Delete the uploaded file and verify it was removed
-        $this->actingAs($this->admin, 'canvas')
-             ->deleteJson('canvas/api/uploads', [$expected_filename])
-             ->assertStatus(204);
-
-        // Confirm that the file no longer exists in storage
         Storage::disk(config('canvas.storage_disk'))->assertMissing($expected_path);
     }
 }

--- a/tests/Http/Controllers/UploadsControllerTest.php
+++ b/tests/Http/Controllers/UploadsControllerTest.php
@@ -48,7 +48,7 @@ class UploadsControllerTest extends TestCase
         $this->assertSame(
             $response->getOriginalContent(),
             Storage::disk(config('canvas.storage_disk'))->url($expected_path)
-        );
+        ); 
 
         // Confirm that the response content is a string (URL)
         $this->assertIsString($response->getContent());

--- a/tests/Http/Controllers/UploadsControllerTest.php
+++ b/tests/Http/Controllers/UploadsControllerTest.php
@@ -29,37 +29,67 @@ class UploadsControllerTest extends TestCase
     {
         Storage::fake(config('canvas.storage_disk'));
 
+        // Simulate an image upload request
+        $file = UploadedFile::fake()->image('sample-image.jpg');
         $response = $this->actingAs($this->admin, 'canvas')
-                         ->postJson('canvas/api/uploads', [$file = UploadedFile::fake()->image('1.jpg')])
+                         ->postJson('canvas/api/uploads', [$file])
                          ->assertSuccessful();
 
-        $path = sprintf('%s/%s/%s', config('canvas.storage_path'), 'images', $file->hashName());
+        // Construct the expected filename based on the unique hash logic
+        $path_parts = pathinfo($file->getClientOriginalName());
+        $first_name = \Illuminate\Support\Str::kebab($path_parts['filename']);
+        $unique_id = substr(md5($path_parts['filename']), 0, 8);
+        $expected_filename = $first_name . '-' . $unique_id . '.' . $path_parts['extension'];
 
+        // Build the expected path in storage
+        $expected_path = sprintf('%s/%s', Canvas::baseStoragePath(), $expected_filename);
+
+        // Assert that the response content is the URL of the stored file
         $this->assertSame(
             $response->getOriginalContent(),
-            Storage::disk(config('canvas.storage_disk'))->url($path)
+            Storage::disk(config('canvas.storage_disk'))->url($expected_path)
         );
 
+        // Confirm that the response content is a string (URL)
         $this->assertIsString($response->getContent());
 
-        Storage::disk(config('canvas.storage_disk'))->assertExists($path);
+        // Assert that the file actually exists in the specified path
+        Storage::disk(config('canvas.storage_disk'))->assertExists($expected_path);
     }
 
     public function testDeleteUploadedImage(): void
     {
         Storage::fake(config('canvas.storage_disk'));
 
+        // Attempt to delete with an empty payload to check validation
         $this->actingAs($this->admin, 'canvas')
-             ->delete('canvas/api/uploads', [
-                 null,
-             ])->assertStatus(400);
+             ->deleteJson('canvas/api/uploads', [null])
+             ->assertStatus(400);
 
+        // Simulate uploading a file to storage
+        $file = UploadedFile::fake()->image('sample-image.jpg');
         $this->actingAs($this->admin, 'canvas')
-             ->deleteJson('canvas/api/uploads', [$file = UploadedFile::fake()->image('1.jpg')])
+             ->postJson('canvas/api/uploads', [$file])
              ->assertSuccessful();
 
-        $path = sprintf('%s/%s/%s', config('canvas.storage_path'), 'images', $file->hashName());
+        // Construct the expected filename based on the unique hash logic
+        $path_parts = pathinfo($file->getClientOriginalName());
+        $first_name = \Illuminate\Support\Str::kebab($path_parts['filename']);
+        $unique_id = substr(md5($path_parts['filename']), 0, 8);
+        $expected_filename = $first_name . '-' . $unique_id . '.' . $path_parts['extension'];
 
-        Storage::disk(config('canvas.storage_disk'))->assertMissing($path);
+        // Build the expected path in storage
+        $expected_path = sprintf('%s/%s', Canvas::baseStoragePath(), $expected_filename);
+
+        // Confirm the file was successfully uploaded
+        Storage::disk(config('canvas.storage_disk'))->assertExists($expected_path);
+
+        // Delete the uploaded file and verify deletion
+        $this->actingAs($this->admin, 'canvas')
+             ->deleteJson('canvas/api/uploads', [$expected_filename])
+             ->assertSuccessful();
+
+        // Confirm that the file has been removed from storage
+        Storage::disk(config('canvas.storage_disk'))->assertMissing($expected_path);
     }
 }


### PR DESCRIPTION
This pull request introduces a new **SEO-friendly naming scheme** for image uploads in the `UploadsController` to ensure that uploaded files have clean, descriptive, and URL-friendly filenames. The following changes have been made:

- **SEO-Friendly Naming Scheme**: 
  - When an image is uploaded, its filename is now generated using a combination of the original filename (converted to kebab-case) and a unique identifier derived from an `md5` hash of the original name, ensuring a short and readable format.
  
- **Test Cases**:
  - A test for **empty upload validation** (`testEmptyUploadIsValidated`), ensuring that empty file uploads are rejected with a `400` response.
  - A test for **uploading an image** (`testUploadedImageCanBeStored`), which verifies that images are uploaded correctly with the newly generated SEO-friendly filename.
  - A test for **deleting an uploaded image** (`testDeleteUploadedImage`), which verifies that images can be deleted after they have been uploaded, and the file no longer exists in storage.

### Benefits:
- **Improved SEO**: The filenames of uploaded images are now more descriptive and user-friendly, which helps improve SEO rankings.
- **Better file management**: Using a unique identifier in the filename ensures that each uploaded file has a unique and predictable name.
- **Test Coverage**: Added test cases validate both the upload functionality and deletion process, ensuring robust coverage of the new naming scheme.

This change enhances the SEO performance of image uploads while maintaining clean, understandable file naming and ensuring the upload and deletion processes work as expected.