### PR TITLE
Makes it possible to use a '/' in the slug of a post

### DIFF
--- a/src/Http/Requests/PostRequest.php
+++ b/src/Http/Requests/PostRequest.php
@@ -27,7 +27,7 @@ class PostRequest extends FormRequest
         return [
             'slug' => [
                 'required',
-                'alpha_dash',
+                'regex:/^[a-zA-Z0-9\/_-]+$/',
                 Rule::unique('canvas_posts')->where(function ($query) {
                     return $query->where('slug', request('slug'))->where('user_id', request()->user('canvas')->id);
                 })->ignore(request('id'))->whereNull('deleted_at'),


### PR DESCRIPTION
Changes the validation for posts slug to a regex instead of using the 'alpha_dash'.

This makes it possible to also create posts with a prefix such as:
- /kb/my-kb-article
- /blog/yet-another-blug